### PR TITLE
chore: Removed Push Trigger from master

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,9 @@ name: CI
 on:
   # Trigger the workflow on push or pull requests, but only for the
   # main branch
-  push:
-    branches:
-    - master
+  #push:
+  #  branches:
+  #  - master
   pull_request:
     branches:
     - master


### PR DESCRIPTION
Removed push trigger since pushing directly to master isn't possible anyways. Tests will be run on Pull requests and are required there.
Avoids duplicate test runs