### PR TITLE
Hotfix/monitoring agents

### DIFF
--- a/sysmonconfig-export.xml
+++ b/sysmonconfig-export.xml
@@ -77,7 +77,6 @@
 		<!--DATA: UtcTime, ProcessGuid, ProcessID, Image, FileVersion, Description, Product, Company, CommandLine, CurrentDirectory, User, LogonGuid, LogonId, TerminalSessionId, IntegrityLevel, Hashes, ParentProcessGuid, ParentProcessId, ParentImage, ParentCommandLine, RuleName-->
 	<RuleGroup name="" groupRelation="or">
 		<ProcessCreate onmatch="exclude">
-			<ParentCommandLine condition="is">"C:\Program Files\Microsoft Monitoring Agent\Agent\MonitoringHost.exe" -Embedding</ParentCommandLine> <!-- SECTION: Azure OMS/MMA Agent -->
 			<CommandLine condition="contains">\Machine\Scripts\Startup\ipamprovisioning.ps1</CommandLine> <!-- Windows IP Address Management (IPAM) -->
 			<!--SECTION: Microsoft Windows-->
 			<CommandLine condition="is">"C:\Windows\system32\cscript.exe" /nologo "MonitorKnowledgeDiscovery.vbs"</CommandLine>
@@ -233,6 +232,10 @@
 			<Image condition="contains">:\Program Files\SplunkUniversalForwarder\bin\</Image> <!--Splunk: Very noisy if using Universal Forwarders-->
 			<ParentImage condition="end with">:\Program Files\SplunkUniversalForwarder\bin\splunkd.exe</ParentImage> <!--Splunk: Very noisy if using Universal Forwarders-->
 			<ParentImage condition="end with">:\Program Files\SplunkUniversalForwarder\bin\splunk.exe</ParentImage> <!--Splunk: Very noisy if using Universal Forwarders-->
+			<!-- SECTION: Azure OMS/MMA Agent -->
+			<Image condition="begin with">C:\Program Files\Microsoft Monitoring Agent\</Image>
+			<ParentImage condition="is">C:\Program Files\Microsoft Monitoring Agent\MonitoringHost.exe</ParentImage>
+			<ParentImage condition="is">C:\Program Files\Microsoft Monitoring Agent\Agent\HealthService.exe</ParentImage>
 		</ProcessCreate>
 	</RuleGroup>
 
@@ -392,6 +395,9 @@
 			<DestinationIp condition="begin with">fe80:0:0:0</DestinationIp> <!--Credit @ITProPaul-->
 			<!-- OneDrive -->
 			<Image condition="end with">\AppData\Local\Microsoft\OneDrive\OneDrive.exe</Image> <!--Microsoft: OneDrive-->
+			<!-- SECTION: Azure OMS/MMA Agent -->
+			<Image condition="begin with">C:\Program Files\Microsoft Monitoring Agent\</Image>
+			<Image condition="begin with">C:\Program Files\OMS Gateway\</Image>
 		</NetworkConnect>
 	</RuleGroup>
 

--- a/sysmonconfig-export.xml
+++ b/sysmonconfig-export.xml
@@ -398,6 +398,8 @@
 			<!-- SECTION: Azure OMS/MMA Agent -->
 			<Image condition="begin with">C:\Program Files\Microsoft Monitoring Agent\</Image>
 			<Image condition="begin with">C:\Program Files\OMS Gateway\</Image>
+			<!-- SECTION: PRTG -->
+			<Image condition="is">C:\Program Files (x86)\PRTG Network Monitor\PRTG Probe.exe</Image>
 		</NetworkConnect>
 	</RuleGroup>
 
@@ -1283,6 +1285,8 @@
 			<QueryName condition="is">status.rapidssl.com</QueryName>
 			<QueryName condition="is">status.thawte.com</QueryName>
 			<QueryName condition="is">ocsp.int-x3.letsencrypt.org</QueryName>
+			<!-- SECTION: PRTG -->
+			<Image condition="is">C:\Program Files (x86)\PRTG Network Monitor\PRTG Probe.exe</Image>
 		</DnsQuery>
 	</RuleGroup>
 

--- a/sysmonconfig-export.xml
+++ b/sysmonconfig-export.xml
@@ -80,7 +80,7 @@
 			<ParentCommandLine condition="is">"C:\Program Files\Microsoft Monitoring Agent\Agent\MonitoringHost.exe" -Embedding</ParentCommandLine> <!-- SECTION: Azure OMS/MMA Agent -->
 			<CommandLine condition="contains">\Machine\Scripts\Startup\ipamprovisioning.ps1</CommandLine> <!-- Windows IP Address Management (IPAM) -->
 			<!--SECTION: Microsoft Windows-->
-			<CommandLine condition="is">C:\Windows\system32\cscript.exe" /nologo "MonitorKnowledgeDiscovery.vbs</CommandLine>
+			<CommandLine condition="is">"C:\Windows\system32\cscript.exe" /nologo "MonitorKnowledgeDiscovery.vbs"</CommandLine>
 			<CommandLine condition="begin with"> "C:\Windows\system32\wermgr.exe" "-queuereporting_svc" </CommandLine> <!--Windows:Windows error reporting/telemetry-->
 			<CommandLine condition="begin with">C:\Windows\system32\DllHost.exe /Processid</CommandLine> <!--Windows-->
 			<CommandLine condition="begin with">C:\Windows\system32\wbem\wmiprvse.exe -Embedding</CommandLine> <!--Windows: WMI provider host-->


### PR DESCRIPTION
Deploying Sysmon together with "Azure OMS/MMA Agent" and "PRTG" creates quite some entries originating from the monitoring components.

This change set excludes the most verbose events from those components to still be able to monitor the "monitoring systems" themselves for malicious activity.