### PR TITLE
Update Config

### DIFF
--- a/sysmonconfig-export-block.xml
+++ b/sysmonconfig-export-block.xml
@@ -1323,7 +1323,6 @@
 			<!-- Executables dropped to suspicious folders -->
 			<TargetFilename condition="begin with">C:\Users\Public\</TargetFilename> <!-- often used staging directories; could cause false positives --> 
 			<TargetFilename condition="begin with">C:\Perflogs\</TargetFilename> <!-- often used staging directories --> 
-			<TargetFilename condition="begin with">C:\Users\;\AppData\LocalLow\</TargetFilename> <!-- often used staging directories --> 
 			<TargetFilename condition="begin with">C:\Windows\Fonts\</TargetFilename> <!-- often used staging directories --> 
 			<TargetFilename condition="begin with">C:\Windows\debug\</TargetFilename> <!-- often used staging directories --> 
 			<TargetFilename condition="begin with">C:\Windows\Tasks\</TargetFilename> <!-- often used staging directories --> 

--- a/sysmonconfig-export-block.xml
+++ b/sysmonconfig-export-block.xml
@@ -33,7 +33,6 @@
 			<!--SECTION: Microsoft Windows-->
 			<CommandLine condition="is">"C:\Windows\system32\cscript.exe" /nologo "MonitorKnowledgeDiscovery.vbs"</CommandLine>
 			<CommandLine condition="begin with"> "C:\Windows\system32\wermgr.exe" "-queuereporting_svc" </CommandLine> <!--Windows:Windows error reporting/telemetry-->
-			<CommandLine condition="begin with">C:\Windows\system32\DllHost.exe /Processid</CommandLine> <!--Windows-->
 			<CommandLine condition="begin with">C:\Windows\system32\wbem\wmiprvse.exe -Embedding</CommandLine> <!--Windows: WMI provider host-->
 			<CommandLine condition="begin with">C:\Windows\system32\wbem\wmiprvse.exe -secured -Embedding</CommandLine> <!--Windows: WMI provider host-->
 			<CommandLine condition="is">C:\Windows\system32\wermgr.exe -upload</CommandLine> <!--Windows:Windows error reporting/telemetry-->
@@ -398,6 +397,8 @@
 		<!--DATA: UtcTime, ProcessGuid, ProcessId, Image, ImageLoaded, Hashes, Signed, Signature, SignatureStatus-->
 	<RuleGroup name="" groupRelation="or">
 		<ImageLoad onmatch="include">
+			<ImageLoaded condition="begin with">C:\Users\Public\</ImageLoaded>
+			<ImageLoaded condition="begin with">C:\PerfLogs\</ImageLoaded>
 			<!--NOTE: Using "include" with no rules means nothing in this section will be logged-->
 		</ImageLoad>
 	</RuleGroup>
@@ -1322,6 +1323,7 @@
 			<!-- Executables dropped to suspicious folders -->
 			<TargetFilename condition="begin with">C:\Users\Public\</TargetFilename> <!-- often used staging directories; could cause false positives --> 
 			<TargetFilename condition="begin with">C:\Perflogs\</TargetFilename> <!-- often used staging directories --> 
+			<TargetFilename condition="begin with">C:\AppData\LocalLow\</TargetFilename> <!-- often used staging directories --> 
 			<TargetFilename condition="begin with">C:\Windows\Fonts\</TargetFilename> <!-- often used staging directories --> 
 			<TargetFilename condition="begin with">C:\Windows\debug\</TargetFilename> <!-- often used staging directories --> 
 			<TargetFilename condition="begin with">C:\Windows\Tasks\</TargetFilename> <!-- often used staging directories --> 
@@ -1350,6 +1352,9 @@
 			<TargetFilename condition="end with">.htm.exe</TargetFilename>
 			<TargetFilename condition="end with">.html.exe</TargetFilename>
 			<TargetFilename condition="end with">.iso.exe</TargetFilename>
+			<TargetFilename condition="end with">.zip.exe</TargetFilename>
+			<TargetFilename condition="end with">.rar.exe</TargetFilename>
+			<TargetFilename condition="end with">.7z.exe</TargetFilename>
 			<!-- Hacktool Blocks based on Imphashes -->
 			<Hashes condition="contains">IMPHASH=BCCA3C247B619DCD13C8CDFF5F123932</Hashes> <!-- PetitPotam -->
 			<Hashes condition="contains">IMPHASH=3A19059BD7688CB88E70005F18EFC439</Hashes> <!-- PetitPotam -->

--- a/sysmonconfig-export-block.xml
+++ b/sysmonconfig-export-block.xml
@@ -1323,7 +1323,7 @@
 			<!-- Executables dropped to suspicious folders -->
 			<TargetFilename condition="begin with">C:\Users\Public\</TargetFilename> <!-- often used staging directories; could cause false positives --> 
 			<TargetFilename condition="begin with">C:\Perflogs\</TargetFilename> <!-- often used staging directories --> 
-			<TargetFilename condition="begin with">C:\AppData\LocalLow\</TargetFilename> <!-- often used staging directories --> 
+			<TargetFilename condition="begin with">C:\Users\;\AppData\LocalLow\</TargetFilename> <!-- often used staging directories --> 
 			<TargetFilename condition="begin with">C:\Windows\Fonts\</TargetFilename> <!-- often used staging directories --> 
 			<TargetFilename condition="begin with">C:\Windows\debug\</TargetFilename> <!-- often used staging directories --> 
 			<TargetFilename condition="begin with">C:\Windows\Tasks\</TargetFilename> <!-- often used staging directories --> 

--- a/sysmonconfig-trace.xml
+++ b/sysmonconfig-trace.xml
@@ -139,7 +139,7 @@
 				<SourceImage condition="is">C:\Program Files\Windows Defender\MsMpEng.exe</SourceImage>
 				<Rule name="MsMpEngVersion" groupRelation="and">
 					<SourceImage condition="begin with">C:\ProgramData\Microsoft\Windows Defender\platform\</SourceImage>
-					<SourceImage condition="end with">\MsMpEng.exe</TargetImage>
+					<SourceImage condition="end with">\MsMpEng.exe</SourceImage>
 				</Rule>
 				<SourceImage condition="is">C:\Program Files\Microsoft VS Code\Code.exe</SourceImage>
 				<SourceImage condition="is">C:\WindowsAzure\Packages\CollectGuestLogs.exe</SourceImage>


### PR DESCRIPTION
- Added more double extensions
- Added basic logging to image load at least from "public folder" instead of nothing
- Removed the "dllhost ProcessID" command line exclusion. As this is important to have for COM hijacking via dllhost