### PR TITLE
feat: add new entries and resolve multiple issues

### DIFF
--- a/sysmonconfig-export-block.xml
+++ b/sysmonconfig-export-block.xml
@@ -399,9 +399,6 @@
 		<!--DATA: UtcTime, ImageLoaded, Hashes, Signed, Signature, SignatureStatus-->
 	<RuleGroup name="" groupRelation="or">
 		<DriverLoad onmatch="exclude">
-			<Signature condition="contains">microsoft</Signature> <!--Exclude signed Microsoft drivers-->
-			<Signature condition="contains">windows</Signature> <!--Exclude signed Microsoft drivers-->
-			<Signature condition="begin with">Intel </Signature> <!--Exclude signed Intel drivers-->
 		</DriverLoad>
 	</RuleGroup>
 

--- a/sysmonconfig-export-block.xml
+++ b/sysmonconfig-export-block.xml
@@ -284,6 +284,12 @@
 			<Image condition="image">tasklist.exe</Image> <!--Windows: List processes, has remote ability -->
 			<Image condition="image">wmic.exe</Image> <!--WindowsManagementInstrumentation: Credit @Cyb3rOps [ https://gist.github.com/Neo23x0/a4b4af9481e01e749409 ] -->
 			<Image condition="image">wscript.exe</Image> <!--WindowsScriptingHost: | Credit @arekfurt -->
+			<Image condition="image">mstsc.exe</Image>
+			<Image condition="image">wsl.exe</Image>
+			<Image condition="image">winget.exe</Image>
+			<Image condition="image">WindowsTerminal.exe</Image>
+			<Image condition="image">wt.exe</Image>
+			<Image condition="image">winlogon.exe</Image>
 			<!--Live of the Land Binaries and scripts (LOLBAS) -->
 			<Image condition="image">bitsadmin.exe</Image> <!-- Windows: Background Intelligent Transfer Service - Can download from URLs -->
 			<Image condition="image">esentutl.exe</Image> <!-- Windows: Database utilities for the ESE - Can fetch from UNC paths -->
@@ -315,6 +321,7 @@
 			<Image condition="image">winexesvc.exe</Image> <!-- Winexe service executable | Credit @Cyb3rOps -->
 			<Image condition="image">nmap.exe</Image>
 			<Image condition="image">psinfo.exe</Image>
+			<Image condition="image">RDCMan.exe</Image>
 			<!--Ports: Suspicious-->
 			<DestinationPort name="SSH" condition="is">22</DestinationPort> <!--SSH protocol, monitor admin connections-->
 			<DestinationPort name="Telnet" condition="is">23</DestinationPort> <!--Telnet protocol, monitor admin connections, insecure-->
@@ -405,8 +412,11 @@
 		<!--DATA: UtcTime, ProcessGuid, ProcessId, Image, ImageLoaded, Hashes, Signed, Signature, SignatureStatus-->
 	<RuleGroup name="" groupRelation="or">
 		<ImageLoad onmatch="include">
-			<ImageLoaded condition="begin with">C:\Users\Public\</ImageLoaded>
 			<ImageLoaded condition="begin with">C:\PerfLogs\</ImageLoaded>
+			<ImageLoaded condition="begin with">C:\Users\Public\</ImageLoaded>
+			<ImageLoaded condition="is">C:\Windows\System32\WLBSCTRL.dll</ImageLoaded> <!-- SCM DLL sideloading -->
+			<ImageLoaded condition="is">C:\Windows\System32\TSMSISrv.dll</ImageLoaded> <!-- SCM DLL sideloading -->
+			<ImageLoaded condition="is">C:\Windows\System32\TSVIPSrv.dll</ImageLoaded> <!-- SCM DLL sideloading -->
 			<!--NOTE: Using "include" with no rules means nothing in this section will be logged-->
 		</ImageLoad>
 	</RuleGroup>
@@ -510,6 +520,7 @@
 			<TargetFilename condition="end with">.dmp</TargetFilename> <!--Process dumps [ (fr) http://blog.gentilkiwi.com/securite/mimikatz/minidump ] -->
 			<TargetFilename condition="end with">.dump</TargetFilename>
 			<TargetFilename condition="end with">.docm</TargetFilename> <!--Microsoft:Office:Word: Macro-->
+			<TargetFilename condition="end with">.evtx</TargetFilename> <!--Eventlog-->
 			<TargetFilename condition="end with">.exe.log</TargetFilename> <!-- [ https://github.com/bitsadmin/nopowershell ] | Credit: @SBousseaden [ https://twitter.com/SBousseaden/status/1137493597769687040 ] -->
 			<TargetFilename condition="end with">.exe</TargetFilename> <!--Executable-->
 			<TargetFilename condition="end with">.hta</TargetFilename> <!--Scripting-->
@@ -538,11 +549,12 @@
 			<TargetFilename condition="end with">.sys</TargetFilename> <!--System driver files-->
 			<TargetFilename condition="end with">.vbe</TargetFilename> <!--VisualBasicScripting-->
 			<TargetFilename condition="end with">.vbs</TargetFilename> <!--VisualBasicScripting-->
+			<TargetFilename condition="end with">.vhd</TargetFilename>
+			<TargetFilename condition="end with">.vhdx</TargetFilename>
 			<TargetFilename condition="end with">.war</TargetFilename>
 			<TargetFilename condition="end with">.wsc</TargetFilename> <!--Scripting | Credit @bartblaze -->
 			<TargetFilename condition="end with">.wsf</TargetFilename> <!--Scripting | Credit @bartblaze -->
 			<TargetFilename condition="end with">.wsh</TargetFilename>
-			<TargetFilename condition="end with">.xls</TargetFilename> <!--Legacy Office files are often used for attacks-->
 			<TargetFilename condition="end with">.xls</TargetFilename><!--Microsoft [ https://medium.com/@threathuntingteam/msxsl-exe-and-wmic-exe-a-way-to-proxy-code-execution-8d524f642b75 ] -->
 			<TargetFilename condition="end with">.xlsm</TargetFilename> <!--Microsoft:Office:Word: Macro-->
 			<TargetFilename name="DefaultUserModified" condition="begin with">C:\Users\Default</TargetFilename> <!--Windows: Changes to default user profile-->

--- a/sysmonconfig-export-block.xml
+++ b/sysmonconfig-export-block.xml
@@ -399,6 +399,9 @@
 		<!--DATA: UtcTime, ImageLoaded, Hashes, Signed, Signature, SignatureStatus-->
 	<RuleGroup name="" groupRelation="or">
 		<DriverLoad onmatch="exclude">
+			<!-- include if needed <Signature condition="contains">microsoft</Signature> Exclude signed Microsoft drivers-->
+			<!-- include if needed <Signature condition="contains">windows</Signature> Exclude signed Microsoft drivers-->
+			<!-- include if needed <Signature condition="begin with">Intel </Signature> Exclude signed Intel drivers-->
 		</DriverLoad>
 	</RuleGroup>
 

--- a/sysmonconfig-export-block.xml
+++ b/sysmonconfig-export-block.xml
@@ -246,6 +246,8 @@
 			<!--Suspicious Windows tools-->
 			<Image condition="image">at.exe</Image> <!--Windows: Remote task scheduling, removed in Win10 | Credit @ion-storm -->
 			<Image condition="image">certutil.exe</Image> <!--Windows: Certificate tool can contact outbound | Credit @ion-storm @FVT [ https://twitter.com/FVT/status/834433734602530817 ] -->
+			<Image condition="image">calc.exe</Image>
+			<Image condition="image">CalculatorApp.exe</Image>
 			<Image condition="image">cmd.exe</Image> <!--Windows: Remote command prompt-->
 			<Image condition="image">cmstp.exe</Image> <!--Windows: Connection manager profiles can launch executables from WebDAV [ https://twitter.com/NickTyrer/status/958450014111633408 ] | Credit @NickTyrer @Oddvarmoe @KyleHanslovan @subTee -->
 			<Image condition="image">cscript.exe</Image> <!--WindowsScriptingHost: | Credit @Cyb3rOps [ https://gist.github.com/Neo23x0/a4b4af9481e01e749409 ] -->
@@ -265,6 +267,7 @@
 			<Image condition="image">net1.exe</Image> <!--Windows: Launched by "net.exe", but it may not detect connections either -->
 			<Image condition="image">notepad.exe</Image> <!--Windows: [ https://secrary.com/ReversingMalware/CoinMiner/ ] [ https://blog.cobaltstrike.com/2013/08/08/why-is-notepad-exe-connecting-to-the-internet/ ] -->
 			<Image condition="image">nslookup.exe</Image> <!--Windows: Retrieve data over DNS -->
+			<Image condition="image">pwsh.exe</Image> <!--Windows: PowerShell 7 -->
 			<Image condition="image">powershell.exe</Image> <!--Windows: PowerShell interface-->
 			<Image condition="image">powershell_ise.exe</Image> <!--Windows: PowerShell interface-->
 			<Image condition="image">qprocess.exe</Image> <!--Windows: [ https://www.first.org/resources/papers/conf2017/APT-Log-Analysis-Tracking-Attack-Tools-by-Audit-Policy-and-Sysmon.pdf ] -->
@@ -491,6 +494,7 @@
 			<TargetFilename name="T1165" condition="contains">\Startup\</TargetFilename> <!--Microsoft:Changes to user's auto-launched files and shortcuts-->
 			<TargetFilename name="OutlookAttachment" condition="contains">\Content.Outlook\</TargetFilename> <!--Microsoft:Outlook: attachments-->
 			<TargetFilename name="Downloads" condition="contains">\Downloads\</TargetFilename> <!--Downloaded files. Does not include "Run" files in IE-->
+			<TargetFilename name="Public" condition="contains">C:\Users\Public\</TargetFilename>
 			<TargetFilename name="T1176" condition="end with">.crx</TargetFilename> <!--Chrome extension-->
 			<TargetFilename condition="end with">.application</TargetFilename> <!--Microsoft:ClickOnce: [ https://blog.netspi.com/all-you-need-is-one-a-clickonce-love-story/ ] -->
 			<TargetFilename condition="end with">.appref-ms</TargetFilename> <!--Microsoft:ClickOnce application | Credit @ion-storm -->
@@ -504,6 +508,7 @@
 			<TargetFilename condition="end with">.dll</TargetFilename> <!--Microsoft:Office:Word: Macro-->
 			<TargetFilename condition="end with">.dmg</TargetFilename> <!--Phishing-->
 			<TargetFilename condition="end with">.dmp</TargetFilename> <!--Process dumps [ (fr) http://blog.gentilkiwi.com/securite/mimikatz/minidump ] -->
+			<TargetFilename condition="end with">.dump</TargetFilename>
 			<TargetFilename condition="end with">.docm</TargetFilename> <!--Microsoft:Office:Word: Macro-->
 			<TargetFilename condition="end with">.exe.log</TargetFilename> <!-- [ https://github.com/bitsadmin/nopowershell ] | Credit: @SBousseaden [ https://twitter.com/SBousseaden/status/1137493597769687040 ] -->
 			<TargetFilename condition="end with">.exe</TargetFilename> <!--Executable-->
@@ -551,6 +556,7 @@
 			<TargetFilename condition="begin with">C:\Windows\SysWOW64\Wbem</TargetFilename> <!--Microsoft:WMI: [ More information: http://2014.hackitoergosum.org/slides/day1_WMI_Shell_Andrei_Dumitrescu.pdf ] -->
 			<TargetFilename condition="begin with">C:\Windows\system32\WindowsPowerShell</TargetFilename> <!--Microsoft:Powershell: Look for modifications for persistence [ https://www.malwarearchaeology.com/cheat-sheets ] -->
 			<TargetFilename condition="begin with">C:\Windows\SysWOW64\WindowsPowerShell</TargetFilename> <!--Microsoft:Powershell: Look for modifications for persistence [ https://www.malwarearchaeology.com/cheat-sheets ] -->
+			<TargetFilename condition="begin with">C:\Program Files\PowerShell\7\</TargetFilename>
 			<TargetFilename name="T1053" condition="begin with">C:\Windows\Tasks\</TargetFilename> <!--Microsoft:ScheduledTasks [ https://attack.mitre.org/wiki/Technique/T1053 ] -->
 			<TargetFilename name="T1053" condition="begin with">C:\Windows\system32\Tasks</TargetFilename> <!--Microsoft:ScheduledTasks [ https://attack.mitre.org/wiki/Technique/T1053 ] -->
 			<TargetFilename name="T1053" condition="begin with">C:\Windows\SysWOW64\Tasks</TargetFilename> <!--Microsoft:ScheduledTasks [ https://attack.mitre.org/wiki/Technique/T1053 ] -->

--- a/sysmonconfig-export-block.xml
+++ b/sysmonconfig-export-block.xml
@@ -1512,7 +1512,7 @@
 			<!-- Executables that should never drop an executable to disk (but may after a previous process injection or if it's malware that uses a legitimate name)-->
 			<Image condition="image">notepad.exe</Image>
 			<Image condition="image">AcroRd32.exe</Image>
-			<Image condition="image">RdrCEF.exe</Image>
+			<Image condition="image">RdrCEF.exe</Image> <!-- RdrCEF was seen dropping a DLL in temp (Example: \AppData\Local\Temp\acrocef_low\4616_1623006624_platform_specific\win_x86\widevinecdm.dll). Comment out this entry if you experience issues (https://github.com/Neo23x0/sysmon-config/issues/43) -->
 			<Image condition="image">mshta.exe</Image>
 			<Image condition="image">hh.exe</Image>
 			<Image condition="image">calc.exe</Image>

--- a/sysmonconfig-export.xml
+++ b/sysmonconfig-export.xml
@@ -442,6 +442,9 @@
 		<!--DATA: UtcTime, ImageLoaded, Hashes, Signed, Signature, SignatureStatus-->
 	<RuleGroup name="" groupRelation="or">
 		<DriverLoad onmatch="exclude">
+			<!-- include if needed <Signature condition="contains">microsoft</Signature> Exclude signed Microsoft drivers-->
+			<!-- include if needed <Signature condition="contains">windows</Signature> Exclude signed Microsoft drivers-->
+			<!-- include if needed <Signature condition="begin with">Intel </Signature> Exclude signed Intel drivers-->
 		</DriverLoad>
 	</RuleGroup>
 

--- a/sysmonconfig-export.xml
+++ b/sysmonconfig-export.xml
@@ -290,6 +290,8 @@
 			<!--Suspicious Windows tools-->
 			<Image condition="image">at.exe</Image> <!--Windows: Remote task scheduling, removed in Win10 | Credit @ion-storm -->
 			<Image condition="image">certutil.exe</Image> <!--Windows: Certificate tool can contact outbound | Credit @ion-storm @FVT [ https://twitter.com/FVT/status/834433734602530817 ] -->
+			<Image condition="image">calc.exe</Image>
+			<Image condition="image">CalculatorApp.exe</Image>
 			<Image condition="image">cmd.exe</Image> <!--Windows: Remote command prompt-->
 			<Image condition="image">cmstp.exe</Image> <!--Windows: Connection manager profiles can launch executables from WebDAV [ https://twitter.com/NickTyrer/status/958450014111633408 ] | Credit @NickTyrer @Oddvarmoe @KyleHanslovan @subTee -->
 			<Image condition="image">cscript.exe</Image> <!--WindowsScriptingHost: | Credit @Cyb3rOps [ https://gist.github.com/Neo23x0/a4b4af9481e01e749409 ] -->
@@ -309,6 +311,7 @@
 			<Image condition="image">net1.exe</Image> <!--Windows: Launched by "net.exe", but it may not detect connections either -->
 			<Image condition="image">notepad.exe</Image> <!--Windows: [ https://secrary.com/ReversingMalware/CoinMiner/ ] [ https://blog.cobaltstrike.com/2013/08/08/why-is-notepad-exe-connecting-to-the-internet/ ] -->
 			<Image condition="image">nslookup.exe</Image> <!--Windows: Retrieve data over DNS -->
+			<Image condition="image">pwsh.exe</Image> <!--Windows: PowerShell 7 -->
 			<Image condition="image">powershell.exe</Image> <!--Windows: PowerShell interface-->
 			<Image condition="image">powershell_ise.exe</Image> <!--Windows: PowerShell interface-->
 			<Image condition="image">qprocess.exe</Image> <!--Windows: [ https://www.first.org/resources/papers/conf2017/APT-Log-Analysis-Tracking-Attack-Tools-by-Audit-Policy-and-Sysmon.pdf ] -->
@@ -533,6 +536,7 @@
 			<TargetFilename name="T1165" condition="contains">\Startup\</TargetFilename> <!--Microsoft:Changes to user's auto-launched files and shortcuts-->
 			<TargetFilename name="OutlookAttachment" condition="contains">\Content.Outlook\</TargetFilename> <!--Microsoft:Outlook: attachments-->
 			<TargetFilename name="Downloads" condition="contains">\Downloads\</TargetFilename> <!--Downloaded files. Does not include "Run" files in IE-->
+			<TargetFilename name="Public" condition="contains">C:\Users\Public\</TargetFilename>
 			<TargetFilename name="T1176" condition="end with">.crx</TargetFilename> <!--Chrome extension-->
 			<TargetFilename condition="end with">.application</TargetFilename> <!--Microsoft:ClickOnce: [ https://blog.netspi.com/all-you-need-is-one-a-clickonce-love-story/ ] -->
 			<TargetFilename condition="end with">.appref-ms</TargetFilename> <!--Microsoft:ClickOnce application | Credit @ion-storm -->
@@ -546,6 +550,7 @@
 			<TargetFilename condition="end with">.dll</TargetFilename> <!--Microsoft:Office:Word: Macro-->
 			<TargetFilename condition="end with">.dmg</TargetFilename> <!--Phishing-->
 			<TargetFilename condition="end with">.dmp</TargetFilename> <!--Process dumps [ (fr) http://blog.gentilkiwi.com/securite/mimikatz/minidump ] -->
+			<TargetFilename condition="end with">.dump</TargetFilename>
 			<TargetFilename condition="end with">.docm</TargetFilename> <!--Microsoft:Office:Word: Macro-->
 			<TargetFilename condition="end with">.exe.log</TargetFilename> <!-- [ https://github.com/bitsadmin/nopowershell ] | Credit: @SBousseaden [ https://twitter.com/SBousseaden/status/1137493597769687040 ] -->
 			<TargetFilename condition="end with">.exe</TargetFilename> <!--Executable-->
@@ -593,6 +598,7 @@
 			<TargetFilename condition="begin with">C:\Windows\SysWOW64\Wbem</TargetFilename> <!--Microsoft:WMI: [ More information: http://2014.hackitoergosum.org/slides/day1_WMI_Shell_Andrei_Dumitrescu.pdf ] -->
 			<TargetFilename condition="begin with">C:\Windows\system32\WindowsPowerShell</TargetFilename> <!--Microsoft:Powershell: Look for modifications for persistence [ https://www.malwarearchaeology.com/cheat-sheets ] -->
 			<TargetFilename condition="begin with">C:\Windows\SysWOW64\WindowsPowerShell</TargetFilename> <!--Microsoft:Powershell: Look for modifications for persistence [ https://www.malwarearchaeology.com/cheat-sheets ] -->
+			<TargetFilename condition="begin with">C:\Program Files\PowerShell\7\</TargetFilename>
 			<TargetFilename name="T1053" condition="begin with">C:\Windows\Tasks\</TargetFilename> <!--Microsoft:ScheduledTasks [ https://attack.mitre.org/wiki/Technique/T1053 ] -->
 			<TargetFilename name="T1053" condition="begin with">C:\Windows\system32\Tasks</TargetFilename> <!--Microsoft:ScheduledTasks [ https://attack.mitre.org/wiki/Technique/T1053 ] -->
 			<TargetFilename name="T1053" condition="begin with">C:\Windows\SysWOW64\Tasks</TargetFilename> <!--Microsoft:ScheduledTasks [ https://attack.mitre.org/wiki/Technique/T1053 ] -->
@@ -911,6 +917,7 @@
 			<TargetFilename condition="contains">Startup</TargetFilename> <!--ADS startup | Example: [ https://www.hybrid-analysis.com/sample/a314f6106633fba4b70f9d6ddbee452e8f8f44a72117749c21243dc93c7ed3ac?environmentId=100 ] -->
 			<TargetFilename condition="end with">.bat</TargetFilename> <!--Batch scripting-->
 			<TargetFilename condition="end with">.cmd</TargetFilename> <!--Batch scripting | Credit @ion-storm -->
+			<TargetFilename condition="end with">.chm</TargetFilename> <!--Batch scripting | Credit @ion-storm -->
 			<TargetFilename condition="end with">.doc</TargetFilename> <!--Office doc potentially with macro -->
 			<TargetFilename condition="end with">.hta</TargetFilename> <!--Scripting-->
 			<TargetFilename condition="end with">.jse</TargetFilename> <!--Registry File-->

--- a/sysmonconfig-export.xml
+++ b/sysmonconfig-export.xml
@@ -81,7 +81,6 @@
 			<!--SECTION: Microsoft Windows-->
 			<CommandLine condition="is">"C:\Windows\system32\cscript.exe" /nologo "MonitorKnowledgeDiscovery.vbs"</CommandLine>
 			<CommandLine condition="begin with"> "C:\Windows\system32\wermgr.exe" "-queuereporting_svc" </CommandLine> <!--Windows:Windows error reporting/telemetry-->
-			<CommandLine condition="begin with">C:\Windows\system32\DllHost.exe /Processid</CommandLine> <!--Windows-->
 			<CommandLine condition="begin with">C:\Windows\system32\wbem\wmiprvse.exe -Embedding</CommandLine> <!--Windows: WMI provider host-->
 			<CommandLine condition="begin with">C:\Windows\system32\wbem\wmiprvse.exe -secured -Embedding</CommandLine> <!--Windows: WMI provider host-->
 			<CommandLine condition="is">C:\Windows\system32\wermgr.exe -upload</CommandLine> <!--Windows:Windows error reporting/telemetry-->
@@ -328,6 +327,12 @@
 			<Image condition="image">tasklist.exe</Image> <!--Windows: List processes, has remote ability -->
 			<Image condition="image">wmic.exe</Image> <!--WindowsManagementInstrumentation: Credit @Cyb3rOps [ https://gist.github.com/Neo23x0/a4b4af9481e01e749409 ] -->
 			<Image condition="image">wscript.exe</Image> <!--WindowsScriptingHost: | Credit @arekfurt -->
+			<Image condition="image">mstsc.exe</Image>
+			<Image condition="image">wsl.exe</Image>
+			<Image condition="image">winget.exe</Image>
+			<Image condition="image">WindowsTerminal.exe</Image>
+			<Image condition="image">wt.exe</Image>
+			<Image condition="image">winlogon.exe</Image>
 			<!--Live of the Land Binaries and scripts (LOLBAS) -->
 			<Image condition="image">bitsadmin.exe</Image> <!-- Windows: Background Intelligent Transfer Service - Can download from URLs -->
 			<Image condition="image">esentutl.exe</Image> <!-- Windows: Database utilities for the ESE - Can fetch from UNC paths -->
@@ -359,6 +364,7 @@
 			<Image condition="image">winexesvc.exe</Image> <!-- Winexe service executable | Credit @Cyb3rOps -->
 			<Image condition="image">nmap.exe</Image>
 			<Image condition="image">psinfo.exe</Image>
+			<Image condition="image">RDCMan.exe</Image>
 			<!--Ports: Suspicious-->
 			<DestinationPort name="SSH" condition="is">22</DestinationPort> <!--SSH protocol, monitor admin connections-->
 			<DestinationPort name="Telnet" condition="is">23</DestinationPort> <!--Telnet protocol, monitor admin connections, insecure-->
@@ -450,6 +456,11 @@
 	<RuleGroup name="" groupRelation="or">
 		<ImageLoad onmatch="include">
 			<!--NOTE: Using "include" with no rules means nothing in this section will be logged-->
+			<ImageLoaded condition="begin with">C:\PerfLogs\</ImageLoaded>
+			<ImageLoaded condition="begin with">C:\Users\Public\</ImageLoaded>
+			<ImageLoaded condition="is">C:\Windows\System32\WLBSCTRL.dll</ImageLoaded> <!-- SCM DLL sideloading -->
+			<ImageLoaded condition="is">C:\Windows\System32\TSMSISrv.dll</ImageLoaded> <!-- SCM DLL sideloading -->
+			<ImageLoaded condition="is">C:\Windows\System32\TSVIPSrv.dll</ImageLoaded> <!-- SCM DLL sideloading -->
 		</ImageLoad>
 	</RuleGroup>
 
@@ -552,6 +563,7 @@
 			<TargetFilename condition="end with">.dmp</TargetFilename> <!--Process dumps [ (fr) http://blog.gentilkiwi.com/securite/mimikatz/minidump ] -->
 			<TargetFilename condition="end with">.dump</TargetFilename>
 			<TargetFilename condition="end with">.docm</TargetFilename> <!--Microsoft:Office:Word: Macro-->
+			<TargetFilename condition="end with">.evtx</TargetFilename> <!--Eventlog-->
 			<TargetFilename condition="end with">.exe.log</TargetFilename> <!-- [ https://github.com/bitsadmin/nopowershell ] | Credit: @SBousseaden [ https://twitter.com/SBousseaden/status/1137493597769687040 ] -->
 			<TargetFilename condition="end with">.exe</TargetFilename> <!--Executable-->
 			<TargetFilename condition="end with">.hta</TargetFilename> <!--Scripting-->
@@ -580,11 +592,12 @@
 			<TargetFilename condition="end with">.sys</TargetFilename> <!--System driver files-->
 			<TargetFilename condition="end with">.vbe</TargetFilename> <!--VisualBasicScripting-->
 			<TargetFilename condition="end with">.vbs</TargetFilename> <!--VisualBasicScripting-->
+			<TargetFilename condition="end with">.vhd</TargetFilename>
+			<TargetFilename condition="end with">.vhdx</TargetFilename>
 			<TargetFilename condition="end with">.war</TargetFilename>
 			<TargetFilename condition="end with">.wsc</TargetFilename> <!--Scripting | Credit @bartblaze -->
 			<TargetFilename condition="end with">.wsf</TargetFilename> <!--Scripting | Credit @bartblaze -->
 			<TargetFilename condition="end with">.wsh</TargetFilename>
-			<TargetFilename condition="end with">.xls</TargetFilename> <!--Legacy Office files are often used for attacks-->
 			<TargetFilename condition="end with">.xls</TargetFilename><!--Microsoft [ https://medium.com/@threathuntingteam/msxsl-exe-and-wmic-exe-a-way-to-proxy-code-execution-8d524f642b75 ] -->
 			<TargetFilename condition="end with">.xlsm</TargetFilename> <!--Microsoft:Office:Word: Macro-->
 			<TargetFilename name="DefaultUserModified" condition="begin with">C:\Users\Default</TargetFilename> <!--Windows: Changes to default user profile-->

--- a/sysmonconfig-export.xml
+++ b/sysmonconfig-export.xml
@@ -442,9 +442,6 @@
 		<!--DATA: UtcTime, ImageLoaded, Hashes, Signed, Signature, SignatureStatus-->
 	<RuleGroup name="" groupRelation="or">
 		<DriverLoad onmatch="exclude">
-			<Signature condition="contains">microsoft</Signature> <!--Exclude signed Microsoft drivers-->
-			<Signature condition="contains">windows</Signature> <!--Exclude signed Microsoft drivers-->
-			<Signature condition="begin with">Intel </Signature> <!--Exclude signed Intel drivers-->
 		</DriverLoad>
 	</RuleGroup>
 

--- a/sysmonconfig-trace.xml
+++ b/sysmonconfig-trace.xml
@@ -236,7 +236,7 @@
 				<Image condition="end with">\Microsoft.Tri.Sensor.Updater.exe</Image> <!-- Microsoft Defender for Identity Sensor -->
 				<Image condition="end with">\TiWorker.exe</Image>
 				<Image condition="is">C:\Windows\system32\compattelrunner.exe</Image>
-				<TargetObject condition="is">\REGISTRY\MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Print\Printers\Microsoft Print to PDF\PrinterDriverData</TargetObject>
+				<TargetObject condition="end with">\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Print\Printers\Microsoft Print to PDF\PrinterDriverData</TargetObject>
 				<TargetObject condition="end with">\LanguageList</TargetObject>
 				<TargetObject condition="end with">\Windows.UI.SettingsAppThreshold.pri</TargetObject>
 				<TargetObject condition="end with">\Software\Microsoft\Windows\CurrentVersion\BackgroundAccessApplications</TargetObject>

--- a/sysmonconfig-trace.xml
+++ b/sysmonconfig-trace.xml
@@ -82,11 +82,6 @@
 		<RuleGroup name="" groupRelation="or">
 			<!-- Event ID 6 == Driver Loaded. Log all drivers except those with the following signatures -->
 			<DriverLoad onmatch="exclude">
-				<Signature condition="contains">microsoft</Signature>
-				<Signature condition="contains">windows</Signature>
-				<Signature condition="contains">symantec</Signature>
-				<Signature condition="is">VMware</Signature>
-				<Signature condition="begin with">Intel </Signature>
 			</DriverLoad>
 		</RuleGroup>
 		<RuleGroup name="" groupRelation="or">

--- a/sysmonconfig-trace.xml
+++ b/sysmonconfig-trace.xml
@@ -12,7 +12,7 @@
    <!-- Capture all hashes -->
    <HashAlgorithms>*</HashAlgorithms>
    <DnsLookup>False</DnsLookup>
-   <ArchiveDirectory>Archive</ArchiveDirectory>
+   <!-- <ArchiveDirectory>Archive</ArchiveDirectory> -->
    <CaptureClipboard/>
    <EventFiltering>
    		<RuleGroup name="" groupRelation="or">


### PR DESCRIPTION
This PR fixes the following issues:

- Fix #50 
- Fix #49
- Fix #48
- Fix #43

It also adds the following entries

- `Calc.exe`, `CalculatorApp.exe`, `mstsc.exe`, `wsl.exe`, `winget.exe`, `WindowsTerminal.exe`, `wt.exe`, `Winlogon.exe`, `RDCMan.exe` and `pwsh.exe` to EID 3
- `C:\Users\Public\`, `.dump` and `C:\Program Files\PowerShell\7\` to EID 11
- Adds new paths to EID 7 event
- Adds new extensions to EID 11: `.vhd` and `.vhdx`
- Remove duplicate entry in EID 11 for `.xls` extension
- Add comment to the block config about the `RdrCEF` binary being able to drop DLLs.
- Remove the driver signature filters as they can easily be spoofed.

TODO

~- [ ] Add more windows system processes to NetworkConnections event~
~- [ ] Order config by field and alphabetical order~