### PR TITLE
Accept EULA cannot combine with loading a config

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ Please report:
 Run with administrator rights
 
 ```batch
-sysmon.exe -accepteula -i sysmonconfig-export.xml
+sysmon.exe -accepteula 
+sysmon.exe -i sysmonconfig-export.xml
 ```
 
 ### Update existing configuration


### PR DESCRIPTION
Accepting the Sysmon EULA and installing a config nowadays need to be on separate lines.