### PR TITLE
Add ssh.exe to monitored image list for NetworkConnect

### DIFF
--- a/sysmonconfig-export.xml
+++ b/sysmonconfig-export.xml
@@ -332,6 +332,7 @@
 			<Image condition="image">WindowsTerminal.exe</Image>
 			<Image condition="image">wt.exe</Image>
 			<Image condition="image">winlogon.exe</Image>
+			<Image condition="image">ssh.exe</Image>
 			<!--Live of the Land Binaries and scripts (LOLBAS) -->
 			<Image condition="image">bitsadmin.exe</Image> <!-- Windows: Background Intelligent Transfer Service - Can download from URLs -->
 			<Image condition="image">esentutl.exe</Image> <!-- Windows: Database utilities for the ESE - Can fetch from UNC paths -->


### PR DESCRIPTION
This will capture the different ssh flag used for lateral movement or persistent e.g. ssh user@ip -R ..